### PR TITLE
Use standard function protect_page() in helpdesk.php

### DIFF
--- a/helpdesk.php
+++ b/helpdesk.php
@@ -1,8 +1,6 @@
 <?php
 require_once 'engine/init.php';
-if (user_logged_in() === false) {
-	header('Location: register.php');
-}
+protect_page();
 include 'layout/overall/header.php';
 
 $view = (isset($_GET['view']) && (int)$_GET['view'] > 0) ? (int)$_GET['view'] : false;


### PR DESCRIPTION
To be consistent I think we should use the standard function protect_page() instead of a custom if statement in helpdesk.php so its the behaviour is the same as in other places.